### PR TITLE
Add forcestart option to domsingester_init.sh

### DIFF
--- a/radio-tv/src/main/scripts/domsingester_init.sh
+++ b/radio-tv/src/main/scripts/domsingester_init.sh
@@ -16,9 +16,11 @@ fi
 
 start()
 {
-    if objectmover_running; then
-        echo "FATAL: Cannot start, ingest-object-mover is running"
-        exit 1
+    if [ -z "$ignore_object_mover" ]; then
+        if objectmover_running; then
+            echo "FATAL: Cannot start, ingest-object-mover is running"
+            exit 1
+        fi
     fi
     rotate_log
     [ -r $STOPFOLDER/stoprunning ] && rm -f $STOPFOLDER/stoprunning && echo "Removing stopfile $STOPFOLDER/stoprunning"
@@ -67,6 +69,12 @@ status()
 
 case $1 in
     start)
+        start
+        ;;
+    forcestart)
+        # We want ingest-object-mover to be able to start the ingester
+        # but of course then we need to skip checking if it is running
+        ignore_object_mover=1
         start
         ;;
     stop)

--- a/radio-tv/src/main/scripts/ingest-object-mover.sh
+++ b/radio-tv/src/main/scripts/ingest-object-mover.sh
@@ -70,7 +70,7 @@ main()
     echo "Hot objects added:    $hotobjectcounter"
     echo "Cold objects updated: $coldobjectcounter"
     # Start the ingester
-    $DOMSINGEST_INIT start
+    $DOMSINGEST_INIT forcestart
 }
 
 # Go to export folder


### PR DESCRIPTION
We want to be able to restart the ingester from ingest-object-mover but
obviously that is not possible when the init script now refuses to start
if ingest-object-mover is running.
As a workaround we add this undocumented option that bypasses the check
and allows ingest-object-mover to start the ingester as before.
